### PR TITLE
feat: add AbortController + 30s timeout to LLM fetch

### DIFF
--- a/src/llm.ts
+++ b/src/llm.ts
@@ -34,28 +34,43 @@ export async function classifyEventWithLlm(event: GuardEvent, config: GuardConfi
     throw new Error('LLM detection is enabled but llm.model is empty')
   }
 
-  const response = await fetch(`${trimTrailingSlash(config.llm.baseUrl)}/chat/completions`, {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${config.llm.apiKey}`,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({
-      model: config.llm.model,
-      temperature: config.llm.temperature,
-      response_format: { type: 'json_object' },
-      messages: [
-        {
-          role: 'system',
-          content: config.llm.systemPrompt,
-        },
-        {
-          role: 'user',
-          content: renderPrompt(config.llm.userPromptTemplate, event),
-        },
-      ],
-    }),
-  })
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), 30_000)
+
+  let response: Response
+  try {
+    response = await fetch(`${trimTrailingSlash(config.llm.baseUrl)}/chat/completions`, {
+      method: 'POST',
+      signal: controller.signal,
+      headers: {
+        Authorization: `Bearer ${config.llm.apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: config.llm.model,
+        temperature: config.llm.temperature,
+        response_format: { type: 'json_object' },
+        messages: [
+          {
+            role: 'system',
+            content: config.llm.systemPrompt,
+          },
+          {
+            role: 'user',
+            content: renderPrompt(config.llm.userPromptTemplate, event),
+          },
+        ],
+      }),
+    })
+  } catch (fetchError) {
+    clearTimeout(timeout)
+    if (fetchError instanceof DOMException && fetchError.name === 'AbortError') {
+      throw new Error('LLM request timed out after 30 seconds')
+    }
+    throw fetchError
+  }
+
+  clearTimeout(timeout)
 
   if (!response.ok) {
     const body = await response.text()


### PR DESCRIPTION
## Summary

`src/llm.ts` calls `fetch()` without an `AbortController` or timeout. If the LLM provider is unresponsive or slow, the entire scan hangs indefinitely since `classifyEventWithLlm` is called serially in the scanner loop.

## Changes

- Added `AbortController` with a 30-second timeout to the LLM `fetch` call
- On timeout, throws a clear error message: `"LLM request timed out after 30 seconds"`
- `clearTimeout` is called in both success and error paths to prevent memory leaks
- Distinguishes `AbortError` from other network errors (DNS, TCP failures pass through unchanged)

Close #1 
