### PR TITLE
docs: add fourth-wave report links and corpus

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A free, open-source defense system that protects GitHub maintainers from spam, h
 
 [What it does](#what-it-does) · [Install](#install) · [Web UI](#web-ui) · [AI Detection](#ai-detection) · [Configuration](#configuration) · [CLI](#cli) · [Contributing](#contributing)
 
-Latest threat report: [Fourth-Wave GitHub Issue Abuse Report](docs/fourth-wave-attack-report.md)
+Latest threat report: [Fourth-Wave GitHub Issue Abuse Report](docs/fourth-wave-attack-report.md) · [Attack Corpus](docs/attack-corpus.md)
 
 Niubi Guard helps maintainers defend their repositories without hiding the policy. You choose the detection signals, users, allowlists, model, prompts, confidence threshold, and response actions. Dry-run is the default. Strong actions only happen when you configure them and run apply mode.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -10,7 +10,7 @@
 
 [能力](#能力) · [安装](#安装) · [Web UI](#web-ui) · [AI 侦测](#ai-侦测) · [配置](#配置) · [CLI](#cli) · [贡献](#贡献)
 
-最新攻击报告：[GitHub Issue 第四轮滥用攻击报告](docs/fourth-wave-attack-report.md)
+最新攻击报告：[GitHub Issue 第四轮滥用攻击报告](docs/fourth-wave-attack-report.md) · [攻击语料库](docs/attack-corpus.md)
 
 Niubi Guard 帮助维护者防护仓库，同时保持策略透明。检测信号、用户名、放行规则、模型、提示词、置信度阈值和响应动作都由你配置。默认是 dry-run。只有当你启用动作并进入 apply mode，强动作才会执行。
 

--- a/docs/attack-corpus.md
+++ b/docs/attack-corpus.md
@@ -1,0 +1,81 @@
+# Niubi Guard Attack Corpus / Niubi Guard 攻击语料库
+
+Last updated: 2026-06-19 Asia/Shanghai
+
+最新更新：2026-06-19，Asia/Shanghai
+
+This corpus turns four observed GitHub issue-abuse waves into reusable defensive training material. Thank you, attackers, for the free data donation. The templates are repetitive, the timing is clustered, and the account metadata is almost courteous in how loudly it explains itself.
+
+本语料库把四轮已观察到的 GitHub Issue 滥用攻击整理为可复用的防护训练材料。感谢攻击者免费投喂数据：模板够重复、时间够聚集、账号画像也足够“贴心”，几乎是在主动帮模型做标注。
+
+## Scope / 范围
+
+| Wave / 波次 | Main signal / 主要信号 | Reuse / 复用方式 |
+| --- | --- | --- |
+| First wave / 第一波 | Newly created blank accounts, synchronized burst, cross-repository issue spam | Baseline timing and account-profile signals |
+| Second wave / 第二波 | Intermittent copy-paste accusations, rotating accounts | Template family expansion |
+| Third wave / 第三波 | Customer repositories targeted, mixed banned and fresh accounts, continued re-entry | Residual-risk and recurrence signals |
+| Fourth wave / 第四波 | 7 April-2026 blank accounts, 2,374 public issues, 629 unique repositories | Current high-confidence report and prompt tuning set |
+
+## Labels / 标签
+
+| Label | Description | 中文说明 |
+| --- | --- | --- |
+| `fake_star_accusation` | Accuses a project of buying, faking, or manipulating stars without constructive evidence | 无建设性证据地指控项目刷星、假星、操纵星标 |
+| `blank_account_wave` | Newly registered or empty-profile accounts posting across many repositories | 新注册或资料空白账号跨仓库批量投递 |
+| `stargazer_cleanup_threat` | Claims GitHub will clean Stargazers, remove traffic, or reset popularity | 声称 GitHub 将清理 Stargazer、清空流量或重置人气 |
+| `github_report_threat` | Uses official-report language as intimidation rather than a good-faith report | 以“递交 GitHub 举报”等官方举报话术施压 |
+| `template_reputation_attack` | Repeated reputation-pressure template with minor title/body changes | 小幅改写后重复投递的声誉施压模板 |
+| `cold_start_account` | Account metadata shows new registration, empty bio, no repos, no followers/following | 账号画像呈现新注册、空 Bio、零仓库、零关注关系 |
+
+## Wording Families / 话术家族
+
+| Family | Sample phrases | 中文样例 | Suggested label |
+| --- | --- | --- | --- |
+| Fake-star warning | `fake stars`, `serious star fraud`, `suspicious Stargazers` | `刷星`, `Star存在严重造假嫌疑`, `虚假 Stargazer` | `fake_star_accusation` |
+| Blank-account narrative | `blank accounts`, `zombie accounts`, `bot stargazers` | `空壳号`, `僵尸号`, `机器人 Stargazer` | `blank_account_wave` |
+| Cleanup threat | `traffic removal`, `Stargazer cleanup`, `popularity reset` | `违规人气清空`, `清理 Stargazer`, `流量清空` | `stargazer_cleanup_threat` |
+| Official-report pressure | `reported to GitHub`, `repository shutdown`, `access closure` | `递交 GitHub 举报`, `项目访问关闭`, `举报递官方` | `github_report_threat` |
+| Fake personal story | `a friend's failed story`, `from excitement to shock`, `a warning from experience` | `讲一个朋友刷星后翻车的真实故事`, `从兴奋到震惊只用了十秒钟`, `过来人的忠告` | `template_reputation_attack` |
+| Moralized confrontation | `if maintainers talked to truth`, `deeply disappointed`, `wake-up call` | `如果维护者和真相对话`, `对项目刷星行为深感失望`, `给其他人提个醒` | `template_reputation_attack` |
+
+## Behavioral Signals / 行为信号
+
+| Signal | English review note | 中文审核说明 |
+| --- | --- | --- |
+| Burst window | Many issues appear within minutes or hours across unrelated repositories | 短时间内跨多个无关仓库集中出现 |
+| Account age | Accounts were created shortly before the campaign and have little normal activity | 账号刚注册不久，正常开发活动很少 |
+| Empty profile | No bio, no public repositories, no followers or following | Bio 为空、无公开仓库、无 followers/following |
+| Repeated title shape | Different accounts reuse the same title rhythm or warning format | 不同账号复用相同标题节奏或警示格式 |
+| Threat framing | Content emphasizes punishment, reports, shutdown, cleanup, or reputation damage | 内容强调惩罚、举报、关闭、清理或声誉打击 |
+| Cross-repo spread | Same wording family appears in many unrelated repositories | 同一话术家族出现在大量无关仓库 |
+
+## Review Guidance / 审核建议
+
+Do not mark good-faith criticism, real security reports, normal bug reports, or specific evidence-based star-quality concerns as malicious. A single keyword is not enough. Prefer a combined signal: repeated wording plus cold-start account metadata plus cross-repository spread.
+
+不要把善意批评、真实安全报告、正常 bug report，或有具体证据的 Star 质量质疑直接判为恶意。单个关键词不够。更可靠的组合是：重复话术 + 冷启动账号画像 + 跨仓库扩散。
+
+## Contribution Welcome / 欢迎补充
+
+Please contribute new corpus entries when you see repeated abuse templates. Useful additions include:
+
+- Redacted sample title and body.
+- Public account report link when the evidence is high-confidence.
+- Timestamp and rough burst window.
+- Account metadata such as creation date, public repositories, followers, following, and bio status.
+- Safely redacted affected-repository count.
+- Suggested label and false-positive notes.
+
+欢迎继续补充新的攻击语料。最有价值的信息包括：
+
+- 打码后的标题和正文样例。
+- 高置信证据下的公开账号举报链接。
+- 时间戳和大致爆发窗口。
+- 账号创建时间、公开仓库数、followers、following、Bio 状态等公开资料。
+- 安全打码后的受影响仓库数量。
+- 建议标签和误伤说明。
+
+And yes, to the people generating these templates: every lazy copy-paste line makes the classifier a little less impressed and a little more accurate.
+
+也顺便提醒继续复制粘贴这些模板的人：每一条偷懒话术都会让分类器少一点惊讶、多一点准确。

--- a/docs/fourth-wave-attack-report.md
+++ b/docs/fourth-wave-attack-report.md
@@ -1,78 +1,104 @@
-# Fourth-Wave GitHub Issue Abuse Report
+# Fourth-Wave GitHub Issue Abuse Report / GitHub Issue 第四波滥用攻击报告
 
 Last updated: 2026-06-19 Asia/Shanghai
 
-This report summarizes GitHub issue-abuse campaigns observed by Niubi Guard's hosted protection data and public GitHub Issue records. The public report uses aggregated statistics and redacted samples; complete evidence is retained in the hosted Guard audit trail for authorized maintainers. It is not an official GitHub determination.
+最新更新：2026-06-19，Asia/Shanghai
 
-## Executive Summary
+This bilingual report summarizes GitHub issue-abuse campaigns observed by Niubi Guard's hosted protection data and public GitHub Issue records. Public samples keep affected repositories redacted; account rows include GitHub abuse-report links so maintainers can report active abuse quickly. This is not an official GitHub determination.
 
-Niubi Guard has now recorded four coordinated abuse waves targeting open-source maintainers through GitHub Issues and comments. The campaigns repeatedly use fake-star accusations, "blank account" or "zombie stargazer" narratives, and threat-style wording about GitHub reports, repository shutdown, traffic removal, or Stargazer cleanup.
+本双语报告汇总 Niubi Guard 官网防护数据与公开 GitHub Issue 记录中观察到的 GitHub Issue 滥用攻击。公开样例继续对受影响仓库打码；攻击账号行提供 GitHub 举报链接，方便维护者快速举报仍在活跃的滥用行为。本记录不代表 GitHub 官方判定。
 
-The fourth wave started on 2026-06-18 UTC and was confirmed by Guard as `github-issue-abuse-wave-2026-06-18-round-4`. It involved 7 high-confidence suspicious accounts, 658 abnormal issues, and 322 affected repositories in about 2.5 hours.
+## Executive Summary / 摘要
 
-## Known Waves
+Niubi Guard has now recorded four coordinated abuse waves targeting open-source maintainers through GitHub Issues and comments. The campaigns repeatedly use fake-star accusations, blank-account or zombie-stargazer narratives, and threat-style wording about GitHub reports, repository shutdown, traffic removal, or Stargazer cleanup.
 
-| Wave | Window (UTC) | Accounts | Abnormal issues | Affected repositories | Risk |
-| --- | --- | ---: | ---: | ---: | --- |
-| `github-abuse-wave-2026-05-08` | 2026-05-07 20:35:50 to 20:47:37 | 5 | 1,584 | 161 | High |
-| `github-issue-abuse-wave-2026-05-31` | 2026-05-26 09:46:51 to 2026-05-31 15:47:32 | 6 | 1,127 | 525 | Critical |
-| `github-issue-attack-2026-05-31` | 2026-05-31 15:38:22 to 16:21:30 | 21 | 38,022 detections | 9 | High |
-| `github-issue-abuse-wave-2026-06-18-round-4` | 2026-06-18 14:36:08 to 17:03:10 | 7 | 658 | 322 | Critical |
+Niubi Guard 目前已记录四轮通过 GitHub Issues 和评论攻击开源维护者的协同滥用事件。这些攻击反复使用刷星指控、空壳号/僵尸 Stargazer 叙事，以及 GitHub 举报、仓库关闭、流量清空、Stargazer 清理等威胁型话术。
 
-The 2026-05-31 data contains two campaign records: one conservative cross-repository campaign and one high-volume Guard detection campaign. The latter includes repeated detections in protected repositories, so its count should be read as Guard detections rather than unique public issues.
+The fourth wave is confirmed as `github-issue-abuse-wave-2026-06-18-round-4`: 7 blank accounts posted 2,374 public issues across 629 unique repositories over about 6.6 hours. The last observed public issue was around 2026-06-19 05:12 Beijing time.
 
-## Fourth Wave Details
+第四波已确认为 `github-issue-abuse-wave-2026-06-18-round-4`：7 个空壳账号约 6.6 小时内在 629 个唯一仓库公开投递 2,374 条 Issue，最后一次公开新增约为北京时间 2026-06-19 05:12。
 
-Guard campaign: `github-issue-abuse-wave-2026-06-18-round-4`
+And, since the attackers have been so generous: thank you for donating clean, repeated, nicely clustered training material to our defense model. It was not the community service you meant to provide, but Niubi Guard accepts the free corpus anyway.
 
-Confirmed pattern:
+顺便也真诚感谢这些攻击者：你们免费提供了干净、重复、聚类明显的防护模型训练语料。虽然这大概不是你们本意上的社区贡献，但 Niubi Guard 还是礼貌收下这份免费投喂。
 
-- Fourth coordinated GitHub issue-abuse wave.
+## Known Waves / 已知波次
+
+| Wave / 波次 | Campaign | Window UTC / UTC 时间窗口 | Accounts / 账号 | Issues or detections / Issue 或检测数 | Affected repositories / 受影响仓库 | Risk / 风险 |
+| --- | --- | --- | ---: | ---: | ---: | --- |
+| 1 / 第一波 | `github-abuse-wave-2026-05-08` | 2026-05-07 20:35:50 to 20:47:37 | 5 | 1,584 | 161 | High |
+| 2 / 第二波 | `github-issue-abuse-wave-2026-05-31` | 2026-05-26 09:46:51 to 2026-05-31 15:47:32 | 6 | 1,127 | 525 | Critical |
+| 3 / 第三波 | `github-issue-attack-2026-05-31` / archive `2026-06-02` | 2026-05-31 15:38:22 to 16:21:30 | 21 / archived 10 | 38,022 detections / archived 2,595 | 9 / archived 892 | High |
+| 4 / 第四波 | `github-issue-abuse-wave-2026-06-18-round-4` | 2026-06-18 14:36:08 to 21:12:37 | 7 | 2,374 | 629 | Critical |
+
+The third-wave row includes both a high-volume Guard detection record and the later archive reconstruction. Detection counts are not the same as unique public issues.
+
+第三波同时展示高频 Guard 检测记录和后续归档补录口径。检测数不等同于唯一公开 Issue 数。
+
+## Fourth-Wave Accounts / 第四波账号
+
+Report links follow the hosted Guard UI pattern: `https://github.com/contact/report-abuse?report=<login>`.
+
+举报链接沿用官网 Guard UI 的做法：`https://github.com/contact/report-abuse?report=<login>`。
+
+| Login | GitHub ID | Registered at UTC | Public repos | Followers | Following | Public issues | Unique repositories | Report / 举报 |
+| --- | ---: | --- | ---: | ---: | ---: | ---: | ---: | --- |
+| `ananjamez108` | 275163558 | 2026-04-10 19:11:28 | 0 | 0 | 0 | 363 | 335 | [Report](https://github.com/contact/report-abuse?report=ananjamez108) |
+| `raxh64` | 274818679 | 2026-04-09 13:07:42 | 0 | 0 | 0 | 357 | 333 | [Report](https://github.com/contact/report-abuse?report=raxh64) |
+| `afsant1993` | 274902061 | 2026-04-09 19:21:48 | 0 | 0 | 0 | 339 | 312 | [Report](https://github.com/contact/report-abuse?report=afsant1993) |
+| `clipe22aving-iti` | 274815712 | 2026-04-09 12:54:58 | 0 | 0 | 0 | 336 | 319 | [Report](https://github.com/contact/report-abuse?report=clipe22aving-iti) |
+| `binybow623` | 274878314 | 2026-04-09 17:18:58 | 0 | 0 | 0 | 333 | 309 | [Report](https://github.com/contact/report-abuse?report=binybow623) |
+| `denitzade` | 274876910 | 2026-04-09 17:12:21 | 0 | 0 | 0 | 326 | 313 | [Report](https://github.com/contact/report-abuse?report=denitzade) |
+| `custpopax` | 274899184 | 2026-04-09 19:06:14 | 0 | 0 | 0 | 320 | 299 | [Report](https://github.com/contact/report-abuse?report=custpopax) |
+
+## Fourth-Wave Pattern / 第四波模式
+
 - April 2026 blank-account cluster.
-- High-frequency cross-repository posting within about 2.5 hours.
+- High-frequency cross-repository posting over about 6.6 hours.
 - Repeated fake-star, blank-account, Stargazer-list and traffic-removal wording.
-- Threat-style GitHub report and repository-shutdown narrative.
+- Continued after the original detection window; no public issues observed after about 2026-06-18 21:15 UTC.
 
-High-confidence account cluster:
+- 2026 年 4 月注册的空壳账号集群。
+- 约 6.6 小时内高频跨仓库投递。
+- 重复命中刷星、空壳号、Stargazer、违规人气清空等话术。
+- 原记录窗口结束后仍继续扩散，约 2026-06-18 21:15 UTC 后暂未发现新增公开 Issue。
 
-| Account | Role | Registered at (UTC) | Public repos | Followers | Following | Issues | Repositories |
-| --- | --- | --- | ---: | ---: | ---: | ---: | ---: |
-| `acct-4w-seed-01` | seed | 2026-04-10 19:11:28 | 0 | 0 | 0 | 151 | 94 |
-| `acct-4w-seed-02` | seed | 2026-04-09 13:07:42 | 0 | 0 | 0 | 141 | 45 |
-| `acct-4w-seed-03` | seed | 2026-04-09 17:12:21 | 0 | 0 | 0 | 120 | 98 |
-| `acct-4w-associated-01` | associated | 2026-04-09 12:54:58 | 0 | 0 | 0 | 70 | 51 |
-| `acct-4w-associated-02` | associated | 2026-04-09 17:18:58 | 0 | 0 | 0 | 65 | 50 |
-| `acct-4w-associated-03` | associated | 2026-04-09 19:21:48 | 0 | 0 | 0 | 64 | 46 |
-| `acct-4w-associated-04` | associated | 2026-04-09 19:06:14 | 0 | 0 | 0 | 47 | 34 |
+## Redacted Samples / 脱敏样例
 
-Sample captured issues and comments, redacted for public reporting:
+Affected repositories remain redacted in the public report. Authorized maintainers can audit the complete mapping in the hosted Guard trail.
 
-| Account | Repository | Title / target | Reason |
+公开报告继续对受影响仓库打码。授权维护者可在官网 Guard 审计记录中查看完整映射。
+
+| Account | Repository | Title / target | Guard reason |
 | --- | --- | --- | --- |
-| `acct-4w-associated-01` | `repo-redacted-01` | `从兴奋到震惊只用了十秒钟（过来人的忠告）` | `deny_list_match` |
-| `acct-4w-associated-01` | `repo-redacted-02` | `对项目刷星行为深感失望` | `keyword_match:刷星,清理,虚假,假数` |
-| `acct-4w-associated-02` | `repo-redacted-03` | `提请注意：本仓库近期涌入的Star存在严重造假嫌疑` | `threat_intel:github-issue-abuse-wave-2026-06-18-round-4` |
-| `acct-4w-associated-02` | `repo-redacted-04` | `[警示] 讲一个朋友刷星后翻车的真实故事（附数据）` | `threat_intel:github-issue-abuse-wave-2026-06-18-round-4` |
-| `acct-4w-associated-03` | `repo-redacted-03` | `如果维护者和真相对话` | `threat_intel:github-issue-abuse-wave-2026-06-18-round-4` |
-| `acct-4w-associated-04` | `repo-redacted-05` | `给其他人提个醒` | `deny_list_match` |
-| `acct-4w-seed-01` | `repo-redacted-05` | `[忠告] 从发现到确认的全过程` | `deny_list_match` |
+| `clipe22aving-iti` | `repo-redacted-01` | `从兴奋到震惊只用了十秒钟（过来人的忠告）` | `deny_list_match` |
+| `clipe22aving-iti` | `repo-redacted-02` | `对项目刷星行为深感失望` | `keyword_match:刷星,清理,虚假,假数` |
+| `binybow623` | `repo-redacted-03` | `提请注意：本仓库近期涌入的Star存在严重造假嫌疑` | `threat_intel:github-issue-abuse-wave-2026-06-18-round-4` |
+| `binybow623` | `repo-redacted-04` | `[警示] 讲一个朋友刷星后翻车的真实故事（附数据）` | `threat_intel:github-issue-abuse-wave-2026-06-18-round-4` |
+| `afsant1993` | `repo-redacted-03` | `如果维护者和真相对话` | `threat_intel:github-issue-abuse-wave-2026-06-18-round-4` |
+| `custpopax` | `repo-redacted-05` | `给其他人提个醒` | `deny_list_match` |
+| `ananjamez108` | `repo-redacted-05` | `[忠告] 从发现到确认的全过程` | `deny_list_match` |
 
-Sample affected repositories are redacted in the public report. Authorized maintainers can audit the complete mapping in the hosted Guard trail.
+## Attack Corpus / 攻击语料库
 
-## Protection Updates In This Repository
+The reusable corpus is maintained in [attack-corpus.md](attack-corpus.md). It groups the four waves into wording families, behavioral signals, review notes, and suggested labels. Users are welcome to contribute new samples, especially repeated templates, timestamps, account metadata, and safely redacted repository evidence.
 
-- Added redacted deny-list placeholders to `guard.config.example.json` to demonstrate the protection format without exposing public report mappings.
-- Added repeated fourth-wave phrases to `guard.config.example.json` as keyword examples.
-- Added exported threat intelligence constants in `src/threat-intel.ts`.
-- Updated the default LLM moderation prompt in `src/prompts.ts` to recognize fake-star accusation campaigns, blank-account waves, Stargazer cleanup narratives, traffic-removal threats, repository-shutdown threats, and GitHub-report threats.
-- Kept the core scanner and detector logic unchanged.
+可复用语料库维护在 [attack-corpus.md](attack-corpus.md)。它把四轮攻击整理为话术家族、行为信号、审核说明和建议标签。欢迎用户继续补充新样本，尤其是重复模板、时间戳、账号公开资料，以及安全打码后的仓库证据。
 
-## Operator Guidance
+Contribution rule: redact victim repositories unless explicit permission is available; include account report links only when the abuse pattern is high-confidence and publicly observable.
 
-Recommended response for maintainers:
+贡献规则：除非已获明确许可，请对受害仓库打码；只有在滥用模式高置信且公开可观察时，才附上账号举报链接。
 
-1. Keep automatic destructive actions disabled until the repository owner is comfortable with the false-positive risk.
-2. Enable keyword detection, deny-list checks, and cold-start account signals first.
-3. Use review mode for LLM moderation before enabling issue deletion, issue locking, or user blocking.
-4. Record sample URLs and action logs in issues so future maintainers can audit why a pattern was added.
-5. Avoid naming normal users from low-confidence searches. Only add accounts that match repeated behavior, public metadata signals, and cross-repository campaign evidence.
+## Maintainer Guidance / 维护者建议
+
+1. Keep destructive actions disabled until the repository owner is comfortable with the false-positive risk.
+2. Enable keyword detection, deny-list checks, cold-start account signals, and LLM review mode first.
+3. Use GitHub report links for active abuse accounts.
+4. Record new samples in the corpus with bilingual notes when possible.
+5. Treat the corpus as defensive training material, not as a place for personal harassment.
+
+1. 在维护者能接受误伤风险前，保持删除、锁定、拉黑等强动作关闭。
+2. 优先启用关键词、deny-list、冷启动账号信号和 LLM review mode。
+3. 对仍活跃的滥用账号使用 GitHub 举报链接。
+4. 新样本尽量以双语说明加入语料库。
+5. 语料库用于防护训练，不用于人身骚扰。


### PR DESCRIPTION
## Summary
- update the fourth-wave report to bilingual English/Chinese
- add GitHub abuse-report links for the seven current fourth-wave accounts using the hosted Guard report-link pattern
- refresh the fourth-wave stats from hosted Guard data: 2,374 public issues across 629 unique repositories
- add a bilingual attack corpus built from the four observed waves and invite user contributions
- keep affected repositories redacted and avoid local-path references

## Verification
- rg check for local paths and affected-repository plaintext
- pnpm check