### PR TITLE
docs: split bilingual docs by locale

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -5,7 +5,7 @@
 # Niubi Guard
 
 <p align="center">
-  <a href="https://github.com/Albert-Weasker/niubi_guard/blob/main/docs/protected-by-niubi-guard.md">
+  <a href="https://github.com/Albert-Weasker/niubi_guard/blob/main/docs/protected-by-niubi-guard.zh-CN.md">
     <img src="https://img.shields.io/badge/protected%20by-niubi_guard-00bcd4?style=for-the-badge" alt="Protected by Niubi Guard" />
   </a>
 </p>
@@ -14,9 +14,9 @@
 
 [Apache-2.0 License](./LICENSE) · [Homepage](#web-ui) · [GitHub](https://github.com/Albert-Weasker/niubi_guard) · [English](./README.md) · [简体中文](./README.zh-CN.md)
 
-[能力](#能力) · [安装](#安装) · [Web UI](#web-ui) · [AI 侦测](#ai-侦测) · [配置](#配置) · [防护徽章](docs/protected-by-niubi-guard.md) · [CLI](#cli) · [贡献](#贡献)
+[能力](#能力) · [安装](#安装) · [Web UI](#web-ui) · [AI 侦测](#ai-侦测) · [配置](#配置) · [防护徽章](docs/protected-by-niubi-guard.zh-CN.md) · [CLI](#cli) · [贡献](#贡献)
 
-最新攻击报告：[GitHub Issue 第四轮滥用攻击报告](docs/fourth-wave-attack-report.md) · [攻击语料库](docs/attack-corpus.md)
+最新攻击报告：[GitHub Issue 第四轮滥用攻击报告](docs/fourth-wave-attack-report.zh-CN.md) · [攻击语料库](docs/attack-corpus.zh-CN.md)
 
 Niubi Guard 帮助维护者防护仓库，同时保持策略透明。检测信号、用户名、放行规则、模型、提示词、置信度阈值和响应动作都由你配置。默认是 dry-run。只有当你启用动作并进入 apply mode，强动作才会执行。
 

--- a/docs/attack-corpus.md
+++ b/docs/attack-corpus.md
@@ -1,62 +1,58 @@
-# Niubi Guard Attack Corpus / Niubi Guard 攻击语料库
+# Niubi Guard Attack Corpus
+
+English | [简体中文](attack-corpus.zh-CN.md)
 
 Last updated: 2026-06-19 Asia/Shanghai
 
-最新更新：2026-06-19，Asia/Shanghai
-
 This corpus turns four observed GitHub issue-abuse waves into reusable defensive training material. Thank you, attackers, for the free data donation. The templates are repetitive, the timing is clustered, and the account metadata is almost courteous in how loudly it explains itself.
 
-本语料库把四轮已观察到的 GitHub Issue 滥用攻击整理为可复用的防护训练材料。感谢攻击者免费投喂数据：模板够重复、时间够聚集、账号画像也足够“贴心”，几乎是在主动帮模型做标注。
+## Scope
 
-## Scope / 范围
-
-| Wave / 波次 | Main signal / 主要信号 | Reuse / 复用方式 |
+| Wave | Main signal | Reuse |
 | --- | --- | --- |
-| First wave / 第一波 | Newly created blank accounts, synchronized burst, cross-repository issue spam | Baseline timing and account-profile signals |
-| Second wave / 第二波 | Intermittent copy-paste accusations, rotating accounts | Template family expansion |
-| Third wave / 第三波 | Customer repositories targeted, mixed banned and fresh accounts, continued re-entry | Residual-risk and recurrence signals |
-| Fourth wave / 第四波 | 7 April-2026 blank accounts, 2,374 public issues, 629 unique repositories | Current high-confidence report and prompt tuning set |
+| First wave | Newly created blank accounts, synchronized burst, cross-repository issue spam | Baseline timing and account-profile signals |
+| Second wave | Intermittent copy-paste accusations, rotating accounts | Template family expansion |
+| Third wave | Customer repositories targeted, mixed banned and fresh accounts, continued re-entry | Residual-risk and recurrence signals |
+| Fourth wave | 7 April-2026 blank accounts, 2,374 public issues, 629 unique repositories | Current high-confidence report and prompt tuning set |
 
-## Labels / 标签
+## Labels
 
-| Label | Description | 中文说明 |
+| Label | Description |
+| --- | --- |
+| `fake_star_accusation` | Accuses a project of buying, faking, or manipulating stars without constructive evidence |
+| `blank_account_wave` | Newly registered or empty-profile accounts posting across many repositories |
+| `stargazer_cleanup_threat` | Claims GitHub will clean Stargazers, remove traffic, or reset popularity |
+| `github_report_threat` | Uses official-report language as intimidation rather than a good-faith report |
+| `template_reputation_attack` | Repeated reputation-pressure template with minor title/body changes |
+| `cold_start_account` | Account metadata shows new registration, empty bio, no repos, no followers/following |
+
+## Wording Families
+
+| Family | Sample phrases | Suggested label |
 | --- | --- | --- |
-| `fake_star_accusation` | Accuses a project of buying, faking, or manipulating stars without constructive evidence | 无建设性证据地指控项目刷星、假星、操纵星标 |
-| `blank_account_wave` | Newly registered or empty-profile accounts posting across many repositories | 新注册或资料空白账号跨仓库批量投递 |
-| `stargazer_cleanup_threat` | Claims GitHub will clean Stargazers, remove traffic, or reset popularity | 声称 GitHub 将清理 Stargazer、清空流量或重置人气 |
-| `github_report_threat` | Uses official-report language as intimidation rather than a good-faith report | 以“递交 GitHub 举报”等官方举报话术施压 |
-| `template_reputation_attack` | Repeated reputation-pressure template with minor title/body changes | 小幅改写后重复投递的声誉施压模板 |
-| `cold_start_account` | Account metadata shows new registration, empty bio, no repos, no followers/following | 账号画像呈现新注册、空 Bio、零仓库、零关注关系 |
+| Fake-star warning | `fake stars`, `serious star fraud`, `suspicious Stargazers`, `刷星`, `Star存在严重造假嫌疑`, `虚假 Stargazer` | `fake_star_accusation` |
+| Blank-account narrative | `blank accounts`, `zombie accounts`, `bot stargazers`, `空壳号`, `僵尸号`, `机器人 Stargazer` | `blank_account_wave` |
+| Cleanup threat | `traffic removal`, `Stargazer cleanup`, `popularity reset`, `违规人气清空`, `清理 Stargazer`, `流量清空` | `stargazer_cleanup_threat` |
+| Official-report pressure | `reported to GitHub`, `repository shutdown`, `access closure`, `递交 GitHub 举报`, `项目访问关闭`, `举报递官方` | `github_report_threat` |
+| Fake personal story | `a friend's failed story`, `from excitement to shock`, `a warning from experience`, `讲一个朋友刷星后翻车的真实故事`, `从兴奋到震惊只用了十秒钟`, `过来人的忠告` | `template_reputation_attack` |
+| Moralized confrontation | `if maintainers talked to truth`, `deeply disappointed`, `wake-up call`, `如果维护者和真相对话`, `对项目刷星行为深感失望`, `给其他人提个醒` | `template_reputation_attack` |
 
-## Wording Families / 话术家族
+## Behavioral Signals
 
-| Family | Sample phrases | 中文样例 | Suggested label |
-| --- | --- | --- | --- |
-| Fake-star warning | `fake stars`, `serious star fraud`, `suspicious Stargazers` | `刷星`, `Star存在严重造假嫌疑`, `虚假 Stargazer` | `fake_star_accusation` |
-| Blank-account narrative | `blank accounts`, `zombie accounts`, `bot stargazers` | `空壳号`, `僵尸号`, `机器人 Stargazer` | `blank_account_wave` |
-| Cleanup threat | `traffic removal`, `Stargazer cleanup`, `popularity reset` | `违规人气清空`, `清理 Stargazer`, `流量清空` | `stargazer_cleanup_threat` |
-| Official-report pressure | `reported to GitHub`, `repository shutdown`, `access closure` | `递交 GitHub 举报`, `项目访问关闭`, `举报递官方` | `github_report_threat` |
-| Fake personal story | `a friend's failed story`, `from excitement to shock`, `a warning from experience` | `讲一个朋友刷星后翻车的真实故事`, `从兴奋到震惊只用了十秒钟`, `过来人的忠告` | `template_reputation_attack` |
-| Moralized confrontation | `if maintainers talked to truth`, `deeply disappointed`, `wake-up call` | `如果维护者和真相对话`, `对项目刷星行为深感失望`, `给其他人提个醒` | `template_reputation_attack` |
+| Signal | Review note |
+| --- | --- |
+| Burst window | Many issues appear within minutes or hours across unrelated repositories |
+| Account age | Accounts were created shortly before the campaign and have little normal activity |
+| Empty profile | No bio, no public repositories, no followers or following |
+| Repeated title shape | Different accounts reuse the same title rhythm or warning format |
+| Threat framing | Content emphasizes punishment, reports, shutdown, cleanup, or reputation damage |
+| Cross-repo spread | Same wording family appears in many unrelated repositories |
 
-## Behavioral Signals / 行为信号
-
-| Signal | English review note | 中文审核说明 |
-| --- | --- | --- |
-| Burst window | Many issues appear within minutes or hours across unrelated repositories | 短时间内跨多个无关仓库集中出现 |
-| Account age | Accounts were created shortly before the campaign and have little normal activity | 账号刚注册不久，正常开发活动很少 |
-| Empty profile | No bio, no public repositories, no followers or following | Bio 为空、无公开仓库、无 followers/following |
-| Repeated title shape | Different accounts reuse the same title rhythm or warning format | 不同账号复用相同标题节奏或警示格式 |
-| Threat framing | Content emphasizes punishment, reports, shutdown, cleanup, or reputation damage | 内容强调惩罚、举报、关闭、清理或声誉打击 |
-| Cross-repo spread | Same wording family appears in many unrelated repositories | 同一话术家族出现在大量无关仓库 |
-
-## Review Guidance / 审核建议
+## Review Guidance
 
 Do not mark good-faith criticism, real security reports, normal bug reports, or specific evidence-based star-quality concerns as malicious. A single keyword is not enough. Prefer a combined signal: repeated wording plus cold-start account metadata plus cross-repository spread.
 
-不要把善意批评、真实安全报告、正常 bug report，或有具体证据的 Star 质量质疑直接判为恶意。单个关键词不够。更可靠的组合是：重复话术 + 冷启动账号画像 + 跨仓库扩散。
-
-## Contribution Welcome / 欢迎补充
+## Contribution Welcome
 
 Please contribute new corpus entries when you see repeated abuse templates. Useful additions include:
 
@@ -67,15 +63,4 @@ Please contribute new corpus entries when you see repeated abuse templates. Usef
 - Safely redacted affected-repository count.
 - Suggested label and false-positive notes.
 
-欢迎继续补充新的攻击语料。最有价值的信息包括：
-
-- 打码后的标题和正文样例。
-- 高置信证据下的公开账号举报链接。
-- 时间戳和大致爆发窗口。
-- 账号创建时间、公开仓库数、followers、following、Bio 状态等公开资料。
-- 安全打码后的受影响仓库数量。
-- 建议标签和误伤说明。
-
 And yes, to the people generating these templates: every lazy copy-paste line makes the classifier a little less impressed and a little more accurate.
-
-也顺便提醒继续复制粘贴这些模板的人：每一条偷懒话术都会让分类器少一点惊讶、多一点准确。

--- a/docs/attack-corpus.zh-CN.md
+++ b/docs/attack-corpus.zh-CN.md
@@ -1,0 +1,66 @@
+# Niubi Guard 攻击语料库
+
+[English](attack-corpus.md) | 简体中文
+
+最新更新：2026-06-19，Asia/Shanghai
+
+本语料库把四轮已观察到的 GitHub Issue 滥用攻击整理为可复用的防护训练材料。感谢攻击者免费投喂数据：模板够重复、时间够聚集、账号画像也足够“贴心”，几乎是在主动帮模型做标注。
+
+## 范围
+
+| 波次 | 主要信号 | 复用方式 |
+| --- | --- | --- |
+| 第一波 | 新注册空白账号、同步爆发、跨仓库 Issue spam | 基线时间窗和账号画像信号 |
+| 第二波 | 间歇性复制粘贴指控、账号轮换 | 扩展模板家族 |
+| 第三波 | 客户仓库被命中、已封禁账号与新号混合、继续回流 | 残余风险和复燃信号 |
+| 第四波 | 7 个 2026 年 4 月注册空壳账号、2,374 条公开 Issue、629 个唯一仓库 | 当前高置信报告和提示词调优集 |
+
+## 标签
+
+| 标签 | 中文说明 |
+| --- | --- |
+| `fake_star_accusation` | 无建设性证据地指控项目刷星、假星、操纵星标 |
+| `blank_account_wave` | 新注册或资料空白账号跨仓库批量投递 |
+| `stargazer_cleanup_threat` | 声称 GitHub 将清理 Stargazer、清空流量或重置人气 |
+| `github_report_threat` | 以“递交 GitHub 举报”等官方举报话术施压 |
+| `template_reputation_attack` | 小幅改写后重复投递的声誉施压模板 |
+| `cold_start_account` | 账号画像呈现新注册、空 Bio、零仓库、零关注关系 |
+
+## 话术家族
+
+| 家族 | 样例 | 建议标签 |
+| --- | --- | --- |
+| 刷星警示 | `fake stars`, `serious star fraud`, `suspicious Stargazers`, `刷星`, `Star存在严重造假嫌疑`, `虚假 Stargazer` | `fake_star_accusation` |
+| 空壳账号叙事 | `blank accounts`, `zombie accounts`, `bot stargazers`, `空壳号`, `僵尸号`, `机器人 Stargazer` | `blank_account_wave` |
+| 清理威胁 | `traffic removal`, `Stargazer cleanup`, `popularity reset`, `违规人气清空`, `清理 Stargazer`, `流量清空` | `stargazer_cleanup_threat` |
+| 官方举报施压 | `reported to GitHub`, `repository shutdown`, `access closure`, `递交 GitHub 举报`, `项目访问关闭`, `举报递官方` | `github_report_threat` |
+| 伪个人故事 | `a friend's failed story`, `from excitement to shock`, `a warning from experience`, `讲一个朋友刷星后翻车的真实故事`, `从兴奋到震惊只用了十秒钟`, `过来人的忠告` | `template_reputation_attack` |
+| 道德化对峙 | `if maintainers talked to truth`, `deeply disappointed`, `wake-up call`, `如果维护者和真相对话`, `对项目刷星行为深感失望`, `给其他人提个醒` | `template_reputation_attack` |
+
+## 行为信号
+
+| 信号 | 审核说明 |
+| --- | --- |
+| 爆发窗口 | 短时间内跨多个无关仓库集中出现 |
+| 账号年龄 | 账号刚注册不久，正常开发活动很少 |
+| 空白资料 | Bio 为空、无公开仓库、无 followers/following |
+| 重复标题形态 | 不同账号复用相同标题节奏或警示格式 |
+| 威胁框架 | 内容强调惩罚、举报、关闭、清理或声誉打击 |
+| 跨仓库扩散 | 同一话术家族出现在大量无关仓库 |
+
+## 审核建议
+
+不要把善意批评、真实安全报告、正常 bug report，或有具体证据的 Star 质量质疑直接判为恶意。单个关键词不够。更可靠的组合是：重复话术 + 冷启动账号画像 + 跨仓库扩散。
+
+## 欢迎补充
+
+欢迎继续补充新的攻击语料。最有价值的信息包括：
+
+- 打码后的标题和正文样例。
+- 高置信证据下的公开账号举报链接。
+- 时间戳和大致爆发窗口。
+- 账号创建时间、公开仓库数、followers、following、Bio 状态等公开资料。
+- 安全打码后的受影响仓库数量。
+- 建议标签和误伤说明。
+
+也顺便提醒继续复制粘贴这些模板的人：每一条偷懒话术都会让分类器少一点惊讶、多一点准确。

--- a/docs/fourth-wave-attack-report.md
+++ b/docs/fourth-wave-attack-report.md
@@ -1,47 +1,35 @@
-# Fourth-Wave GitHub Issue Abuse Report / GitHub Issue 第四波滥用攻击报告
+# Fourth-Wave GitHub Issue Abuse Report
+
+English | [简体中文](fourth-wave-attack-report.zh-CN.md)
 
 Last updated: 2026-06-19 Asia/Shanghai
 
-最新更新：2026-06-19，Asia/Shanghai
+This report summarizes GitHub issue-abuse campaigns observed by Niubi Guard's hosted protection data and public GitHub Issue records. Public samples keep affected repositories redacted; account rows include GitHub abuse-report links so maintainers can report active abuse quickly. This is not an official GitHub determination.
 
-This bilingual report summarizes GitHub issue-abuse campaigns observed by Niubi Guard's hosted protection data and public GitHub Issue records. Public samples keep affected repositories redacted; account rows include GitHub abuse-report links so maintainers can report active abuse quickly. This is not an official GitHub determination.
-
-本双语报告汇总 Niubi Guard 官网防护数据与公开 GitHub Issue 记录中观察到的 GitHub Issue 滥用攻击。公开样例继续对受影响仓库打码；攻击账号行提供 GitHub 举报链接，方便维护者快速举报仍在活跃的滥用行为。本记录不代表 GitHub 官方判定。
-
-## Executive Summary / 摘要
+## Executive Summary
 
 Niubi Guard has now recorded four coordinated abuse waves targeting open-source maintainers through GitHub Issues and comments. The campaigns repeatedly use fake-star accusations, blank-account or zombie-stargazer narratives, and threat-style wording about GitHub reports, repository shutdown, traffic removal, or Stargazer cleanup.
 
-Niubi Guard 目前已记录四轮通过 GitHub Issues 和评论攻击开源维护者的协同滥用事件。这些攻击反复使用刷星指控、空壳号/僵尸 Stargazer 叙事，以及 GitHub 举报、仓库关闭、流量清空、Stargazer 清理等威胁型话术。
-
 The fourth wave is confirmed as `github-issue-abuse-wave-2026-06-18-round-4`: 7 blank accounts posted 2,374 public issues across 629 unique repositories over about 6.6 hours. The last observed public issue was around 2026-06-19 05:12 Beijing time.
-
-第四波已确认为 `github-issue-abuse-wave-2026-06-18-round-4`：7 个空壳账号约 6.6 小时内在 629 个唯一仓库公开投递 2,374 条 Issue，最后一次公开新增约为北京时间 2026-06-19 05:12。
 
 And, since the attackers have been so generous: thank you for donating clean, repeated, nicely clustered training material to our defense model. It was not the community service you meant to provide, but Niubi Guard accepts the free corpus anyway.
 
-顺便也真诚感谢这些攻击者：你们免费提供了干净、重复、聚类明显的防护模型训练语料。虽然这大概不是你们本意上的社区贡献，但 Niubi Guard 还是礼貌收下这份免费投喂。
+## Known Waves
 
-## Known Waves / 已知波次
-
-| Wave / 波次 | Campaign | Window UTC / UTC 时间窗口 | Accounts / 账号 | Issues or detections / Issue 或检测数 | Affected repositories / 受影响仓库 | Risk / 风险 |
+| Wave | Campaign | Window UTC | Accounts | Issues or detections | Affected repositories | Risk |
 | --- | --- | --- | ---: | ---: | ---: | --- |
-| 1 / 第一波 | `github-abuse-wave-2026-05-08` | 2026-05-07 20:35:50 to 20:47:37 | 5 | 1,584 | 161 | High |
-| 2 / 第二波 | `github-issue-abuse-wave-2026-05-31` | 2026-05-26 09:46:51 to 2026-05-31 15:47:32 | 6 | 1,127 | 525 | Critical |
-| 3 / 第三波 | `github-issue-attack-2026-05-31` / archive `2026-06-02` | 2026-05-31 15:38:22 to 16:21:30 | 21 / archived 10 | 38,022 detections / archived 2,595 | 9 / archived 892 | High |
-| 4 / 第四波 | `github-issue-abuse-wave-2026-06-18-round-4` | 2026-06-18 14:36:08 to 21:12:37 | 7 | 2,374 | 629 | Critical |
+| 1 | `github-abuse-wave-2026-05-08` | 2026-05-07 20:35:50 to 20:47:37 | 5 | 1,584 | 161 | High |
+| 2 | `github-issue-abuse-wave-2026-05-31` | 2026-05-26 09:46:51 to 2026-05-31 15:47:32 | 6 | 1,127 | 525 | Critical |
+| 3 | `github-issue-attack-2026-05-31` with archive `2026-06-02` | 2026-05-31 15:38:22 to 16:21:30 | 21, archived 10 | 38,022 detections, archived 2,595 | 9, archived 892 | High |
+| 4 | `github-issue-abuse-wave-2026-06-18-round-4` | 2026-06-18 14:36:08 to 21:12:37 | 7 | 2,374 | 629 | Critical |
 
 The third-wave row includes both a high-volume Guard detection record and the later archive reconstruction. Detection counts are not the same as unique public issues.
 
-第三波同时展示高频 Guard 检测记录和后续归档补录口径。检测数不等同于唯一公开 Issue 数。
-
-## Fourth-Wave Accounts / 第四波账号
+## Fourth-Wave Accounts
 
 Report links follow the hosted Guard UI pattern: `https://github.com/contact/report-abuse?report=<login>`.
 
-举报链接沿用官网 Guard UI 的做法：`https://github.com/contact/report-abuse?report=<login>`。
-
-| Login | GitHub ID | Registered at UTC | Public repos | Followers | Following | Public issues | Unique repositories | Report / 举报 |
+| Login | GitHub ID | Registered at UTC | Public repos | Followers | Following | Public issues | Unique repositories | Report |
 | --- | ---: | --- | ---: | ---: | ---: | ---: | ---: | --- |
 | `ananjamez108` | 275163558 | 2026-04-10 19:11:28 | 0 | 0 | 0 | 363 | 335 | [Report](https://github.com/contact/report-abuse?report=ananjamez108) |
 | `raxh64` | 274818679 | 2026-04-09 13:07:42 | 0 | 0 | 0 | 357 | 333 | [Report](https://github.com/contact/report-abuse?report=raxh64) |
@@ -51,25 +39,18 @@ Report links follow the hosted Guard UI pattern: `https://github.com/contact/rep
 | `denitzade` | 274876910 | 2026-04-09 17:12:21 | 0 | 0 | 0 | 326 | 313 | [Report](https://github.com/contact/report-abuse?report=denitzade) |
 | `custpopax` | 274899184 | 2026-04-09 19:06:14 | 0 | 0 | 0 | 320 | 299 | [Report](https://github.com/contact/report-abuse?report=custpopax) |
 
-## Fourth-Wave Pattern / 第四波模式
+## Fourth-Wave Pattern
 
 - April 2026 blank-account cluster.
 - High-frequency cross-repository posting over about 6.6 hours.
 - Repeated fake-star, blank-account, Stargazer-list and traffic-removal wording.
 - Continued after the original detection window; no public issues observed after about 2026-06-18 21:15 UTC.
 
-- 2026 年 4 月注册的空壳账号集群。
-- 约 6.6 小时内高频跨仓库投递。
-- 重复命中刷星、空壳号、Stargazer、违规人气清空等话术。
-- 原记录窗口结束后仍继续扩散，约 2026-06-18 21:15 UTC 后暂未发现新增公开 Issue。
-
-## Redacted Samples / 脱敏样例
+## Redacted Samples
 
 Affected repositories remain redacted in the public report. Authorized maintainers can audit the complete mapping in the hosted Guard trail.
 
-公开报告继续对受影响仓库打码。授权维护者可在官网 Guard 审计记录中查看完整映射。
-
-| Account | Repository | Title / target | Guard reason |
+| Account | Repository | Title or target | Guard reason |
 | --- | --- | --- | --- |
 | `clipe22aving-iti` | `repo-redacted-01` | `从兴奋到震惊只用了十秒钟（过来人的忠告）` | `deny_list_match` |
 | `clipe22aving-iti` | `repo-redacted-02` | `对项目刷星行为深感失望` | `keyword_match:刷星,清理,虚假,假数` |
@@ -79,26 +60,16 @@ Affected repositories remain redacted in the public report. Authorized maintaine
 | `custpopax` | `repo-redacted-05` | `给其他人提个醒` | `deny_list_match` |
 | `ananjamez108` | `repo-redacted-05` | `[忠告] 从发现到确认的全过程` | `deny_list_match` |
 
-## Attack Corpus / 攻击语料库
+## Attack Corpus
 
 The reusable corpus is maintained in [attack-corpus.md](attack-corpus.md). It groups the four waves into wording families, behavioral signals, review notes, and suggested labels. Users are welcome to contribute new samples, especially repeated templates, timestamps, account metadata, and safely redacted repository evidence.
 
-可复用语料库维护在 [attack-corpus.md](attack-corpus.md)。它把四轮攻击整理为话术家族、行为信号、审核说明和建议标签。欢迎用户继续补充新样本，尤其是重复模板、时间戳、账号公开资料，以及安全打码后的仓库证据。
-
 Contribution rule: redact victim repositories unless explicit permission is available; include account report links only when the abuse pattern is high-confidence and publicly observable.
 
-贡献规则：除非已获明确许可，请对受害仓库打码；只有在滥用模式高置信且公开可观察时，才附上账号举报链接。
-
-## Maintainer Guidance / 维护者建议
+## Maintainer Guidance
 
 1. Keep destructive actions disabled until the repository owner is comfortable with the false-positive risk.
 2. Enable keyword detection, deny-list checks, cold-start account signals, and LLM review mode first.
 3. Use GitHub report links for active abuse accounts.
 4. Record new samples in the corpus with bilingual notes when possible.
 5. Treat the corpus as defensive training material, not as a place for personal harassment.
-
-1. 在维护者能接受误伤风险前，保持删除、锁定、拉黑等强动作关闭。
-2. 优先启用关键词、deny-list、冷启动账号信号和 LLM review mode。
-3. 对仍活跃的滥用账号使用 GitHub 举报链接。
-4. 新样本尽量以双语说明加入语料库。
-5. 语料库用于防护训练，不用于人身骚扰。

--- a/docs/fourth-wave-attack-report.zh-CN.md
+++ b/docs/fourth-wave-attack-report.zh-CN.md
@@ -1,0 +1,75 @@
+# GitHub Issue 第四波滥用攻击报告
+
+[English](fourth-wave-attack-report.md) | 简体中文
+
+最新更新：2026-06-19，Asia/Shanghai
+
+本报告汇总 Niubi Guard 官网防护数据与公开 GitHub Issue 记录中观察到的 GitHub Issue 滥用攻击。公开样例继续对受影响仓库打码；攻击账号行提供 GitHub 举报链接，方便维护者快速举报仍在活跃的滥用行为。本记录不代表 GitHub 官方判定。
+
+## 摘要
+
+Niubi Guard 目前已记录四轮通过 GitHub Issues 和评论攻击开源维护者的协同滥用事件。这些攻击反复使用刷星指控、空壳号/僵尸 Stargazer 叙事，以及 GitHub 举报、仓库关闭、流量清空、Stargazer 清理等威胁型话术。
+
+第四波已确认为 `github-issue-abuse-wave-2026-06-18-round-4`：7 个空壳账号约 6.6 小时内在 629 个唯一仓库公开投递 2,374 条 Issue，最后一次公开新增约为北京时间 2026-06-19 05:12。
+
+顺便也真诚感谢这些攻击者：你们免费提供了干净、重复、聚类明显的防护模型训练语料。虽然这大概不是你们本意上的社区贡献，但 Niubi Guard 还是礼貌收下这份免费投喂。
+
+## 已知波次
+
+| 波次 | Campaign | UTC 时间窗口 | 账号 | Issue 或检测数 | 受影响仓库 | 风险 |
+| --- | --- | --- | ---: | ---: | ---: | --- |
+| 第一波 | `github-abuse-wave-2026-05-08` | 2026-05-07 20:35:50 到 20:47:37 | 5 | 1,584 | 161 | High |
+| 第二波 | `github-issue-abuse-wave-2026-05-31` | 2026-05-26 09:46:51 到 2026-05-31 15:47:32 | 6 | 1,127 | 525 | Critical |
+| 第三波 | `github-issue-attack-2026-05-31`，归档 `2026-06-02` | 2026-05-31 15:38:22 到 16:21:30 | 21，归档 10 | 38,022 次检测，归档 2,595 | 9，归档 892 | High |
+| 第四波 | `github-issue-abuse-wave-2026-06-18-round-4` | 2026-06-18 14:36:08 到 21:12:37 | 7 | 2,374 | 629 | Critical |
+
+第三波同时展示高频 Guard 检测记录和后续归档补录口径。检测数不等同于唯一公开 Issue 数。
+
+## 第四波账号
+
+举报链接沿用官网 Guard UI 的做法：`https://github.com/contact/report-abuse?report=<login>`。
+
+| Login | GitHub ID | 注册时间 UTC | 公开仓库 | Followers | Following | 公开 Issues | 唯一仓库 | 举报 |
+| --- | ---: | --- | ---: | ---: | ---: | ---: | ---: | --- |
+| `ananjamez108` | 275163558 | 2026-04-10 19:11:28 | 0 | 0 | 0 | 363 | 335 | [举报](https://github.com/contact/report-abuse?report=ananjamez108) |
+| `raxh64` | 274818679 | 2026-04-09 13:07:42 | 0 | 0 | 0 | 357 | 333 | [举报](https://github.com/contact/report-abuse?report=raxh64) |
+| `afsant1993` | 274902061 | 2026-04-09 19:21:48 | 0 | 0 | 0 | 339 | 312 | [举报](https://github.com/contact/report-abuse?report=afsant1993) |
+| `clipe22aving-iti` | 274815712 | 2026-04-09 12:54:58 | 0 | 0 | 0 | 336 | 319 | [举报](https://github.com/contact/report-abuse?report=clipe22aving-iti) |
+| `binybow623` | 274878314 | 2026-04-09 17:18:58 | 0 | 0 | 0 | 333 | 309 | [举报](https://github.com/contact/report-abuse?report=binybow623) |
+| `denitzade` | 274876910 | 2026-04-09 17:12:21 | 0 | 0 | 0 | 326 | 313 | [举报](https://github.com/contact/report-abuse?report=denitzade) |
+| `custpopax` | 274899184 | 2026-04-09 19:06:14 | 0 | 0 | 0 | 320 | 299 | [举报](https://github.com/contact/report-abuse?report=custpopax) |
+
+## 第四波模式
+
+- 2026 年 4 月注册的空壳账号集群。
+- 约 6.6 小时内高频跨仓库投递。
+- 重复命中刷星、空壳号、Stargazer、违规人气清空等话术。
+- 原记录窗口结束后仍继续扩散，约 2026-06-18 21:15 UTC 后暂未发现新增公开 Issue。
+
+## 脱敏样例
+
+公开报告继续对受影响仓库打码。授权维护者可在官网 Guard 审计记录中查看完整映射。
+
+| 账号 | 仓库 | 标题或目标 | Guard 原因 |
+| --- | --- | --- | --- |
+| `clipe22aving-iti` | `repo-redacted-01` | `从兴奋到震惊只用了十秒钟（过来人的忠告）` | `deny_list_match` |
+| `clipe22aving-iti` | `repo-redacted-02` | `对项目刷星行为深感失望` | `keyword_match:刷星,清理,虚假,假数` |
+| `binybow623` | `repo-redacted-03` | `提请注意：本仓库近期涌入的Star存在严重造假嫌疑` | `threat_intel:github-issue-abuse-wave-2026-06-18-round-4` |
+| `binybow623` | `repo-redacted-04` | `[警示] 讲一个朋友刷星后翻车的真实故事（附数据）` | `threat_intel:github-issue-abuse-wave-2026-06-18-round-4` |
+| `afsant1993` | `repo-redacted-03` | `如果维护者和真相对话` | `threat_intel:github-issue-abuse-wave-2026-06-18-round-4` |
+| `custpopax` | `repo-redacted-05` | `给其他人提个醒` | `deny_list_match` |
+| `ananjamez108` | `repo-redacted-05` | `[忠告] 从发现到确认的全过程` | `deny_list_match` |
+
+## 攻击语料库
+
+可复用语料库维护在 [attack-corpus.zh-CN.md](attack-corpus.zh-CN.md)。它把四轮攻击整理为话术家族、行为信号、审核说明和建议标签。欢迎用户继续补充新样本，尤其是重复模板、时间戳、账号公开资料，以及安全打码后的仓库证据。
+
+贡献规则：除非已获明确许可，请对受害仓库打码；只有在滥用模式高置信且公开可观察时，才附上账号举报链接。
+
+## 维护者建议
+
+1. 在维护者能接受误伤风险前，保持删除、锁定、拉黑等强动作关闭。
+2. 优先启用关键词、deny-list、冷启动账号信号和 LLM review mode。
+3. 对仍活跃的滥用账号使用 GitHub 举报链接。
+4. 新样本尽量以双语说明加入语料库。
+5. 语料库用于防护训练，不用于人身骚扰。

--- a/docs/protected-by-niubi-guard.md
+++ b/docs/protected-by-niubi-guard.md
@@ -1,20 +1,16 @@
-# Protected by Niubi Guard Badge / Niubi Guard 防护徽章
+# Protected by Niubi Guard Badge
+
+English | [简体中文](protected-by-niubi-guard.zh-CN.md)
 
 This document defines the lightweight badge protocol for repositories, websites, and documentation sites protected by Niubi Guard.
 
-本文定义 Niubi Guard 防护徽章的轻量协议，适用于已经安装、部署或接入 Niubi Guard 的仓库、官网和文档站。
-
-## Badge Meaning / 徽章含义
+## Badge Meaning
 
 `Protected by Niubi Guard` means the project has enabled Niubi Guard or an equivalent hosted Niubi Guard policy to help detect and respond to repository abuse, including spam Issues, coordinated harassment, fake-star accusation campaigns, cold-start account waves, and repeated attack templates.
 
-`Protected by Niubi Guard` 表示该项目已启用 Niubi Guard 或等价的 Niubi Guard 托管防护策略，用于辅助识别和处置仓库滥用行为，包括垃圾 Issue、协同骚扰、刷星污蔑、冷启动账号攻击和重复攻击模板。
-
 The badge is a transparency signal, not a guarantee that every abusive interaction will be removed instantly.
 
-徽章是透明度标识，不承诺所有恶意互动都会被立即删除。
-
-## Use Requirements / 使用条件
+## Use Requirements
 
 You may display the badge when at least one condition is true:
 
@@ -23,24 +19,15 @@ You may display the badge when at least one condition is true:
 - The repository has a documented Niubi Guard policy and review workflow.
 - The project is a demo, integration, or documentation example for Niubi Guard.
 
-满足以下任一条件时，可以展示该徽章：
-
-- 仓库正在运行开源 Niubi Guard CLI 或 scanner。
-- 仓库正在使用 Niubi Guard 托管服务。
-- 仓库具有明确的 Niubi Guard 防护策略和审核流程。
-- 项目是 Niubi Guard 的演示、集成或文档示例。
-
 Please do not use the badge to imply GitHub endorsement, official certification, or a zero-abuse guarantee.
 
-请不要用该徽章暗示 GitHub 官方背书、官方认证或“零滥用”保证。
-
-## Recommended Markdown / 推荐 Markdown
+## Recommended Markdown
 
 ```markdown
 [![Protected by Niubi Guard](https://img.shields.io/badge/protected%20by-niubi_guard-00bcd4?style=for-the-badge)](https://github.com/Albert-Weasker/niubi_guard/blob/main/docs/protected-by-niubi-guard.md)
 ```
 
-## Recommended HTML / 推荐 HTML
+## Recommended HTML
 
 ```html
 <a href="https://github.com/Albert-Weasker/niubi_guard/blob/main/docs/protected-by-niubi-guard.md" rel="noopener">
@@ -51,7 +38,7 @@ Please do not use the badge to imply GitHub endorsement, official certification,
 </a>
 ```
 
-## Text-Only Embed / 纯文本嵌入
+## Text-Only Embed
 
 ```html
 <a href="https://github.com/Albert-Weasker/niubi_guard/blob/main/docs/protected-by-niubi-guard.md" rel="noopener">
@@ -59,13 +46,7 @@ Please do not use the badge to imply GitHub endorsement, official certification,
 </a>
 ```
 
-```html
-<a href="https://github.com/Albert-Weasker/niubi_guard/blob/main/docs/protected-by-niubi-guard.md" rel="noopener">
-  此仓库正在由 Niubi Guard 防护。
-</a>
-```
-
-## Website Snippet / 官网或文档站片段
+## Website Snippet
 
 ```html
 <section aria-label="Repository protection status">
@@ -79,11 +60,9 @@ Please do not use the badge to imply GitHub endorsement, official certification,
 </section>
 ```
 
-## Future Dynamic Badge / 未来动态徽章
+## Future Dynamic Badge
 
 The static Shields badge is the current recommended embed. A hosted dynamic endpoint may be introduced later:
-
-当前推荐使用静态 Shields 徽章。未来可以增加官网动态端点：
 
 ```html
 <img
@@ -94,10 +73,6 @@ The static Shields badge is the current recommended embed. A hosted dynamic endp
 
 When a dynamic endpoint exists, it should only return a positive protection status for repositories that have opted in or are verifiably protected.
 
-如果未来上线动态端点，只有主动接入或可验证已防护的仓库才应返回正向防护状态。
-
-## Removal / 移除
+## Removal
 
 Remove the badge if Niubi Guard is no longer deployed, if the repository no longer maintains a Guard policy, or if the badge would mislead users about the protection status.
-
-如果不再部署 Niubi Guard、不再维护 Guard 策略，或徽章会误导用户理解防护状态，请移除该徽章。

--- a/docs/protected-by-niubi-guard.zh-CN.md
+++ b/docs/protected-by-niubi-guard.zh-CN.md
@@ -1,0 +1,78 @@
+# Niubi Guard 防护徽章
+
+[English](protected-by-niubi-guard.md) | 简体中文
+
+本文定义 Niubi Guard 防护徽章的轻量协议，适用于已经安装、部署或接入 Niubi Guard 的仓库、官网和文档站。
+
+## 徽章含义
+
+`Protected by Niubi Guard` 表示该项目已启用 Niubi Guard 或等价的 Niubi Guard 托管防护策略，用于辅助识别和处置仓库滥用行为，包括垃圾 Issue、协同骚扰、刷星污蔑、冷启动账号攻击和重复攻击模板。
+
+徽章是透明度标识，不承诺所有恶意互动都会被立即删除。
+
+## 使用条件
+
+满足以下任一条件时，可以展示该徽章：
+
+- 仓库正在运行开源 Niubi Guard CLI 或 scanner。
+- 仓库正在使用 Niubi Guard 托管服务。
+- 仓库具有明确的 Niubi Guard 防护策略和审核流程。
+- 项目是 Niubi Guard 的演示、集成或文档示例。
+
+请不要用该徽章暗示 GitHub 官方背书、官方认证或“零滥用”保证。
+
+## 推荐 Markdown
+
+```markdown
+[![Protected by Niubi Guard](https://img.shields.io/badge/protected%20by-niubi_guard-00bcd4?style=for-the-badge)](https://github.com/Albert-Weasker/niubi_guard/blob/main/docs/protected-by-niubi-guard.zh-CN.md)
+```
+
+## 推荐 HTML
+
+```html
+<a href="https://github.com/Albert-Weasker/niubi_guard/blob/main/docs/protected-by-niubi-guard.zh-CN.md" rel="noopener">
+  <img
+    src="https://img.shields.io/badge/protected%20by-niubi_guard-00bcd4?style=for-the-badge"
+    alt="Protected by Niubi Guard"
+  />
+</a>
+```
+
+## 纯文本嵌入
+
+```html
+<a href="https://github.com/Albert-Weasker/niubi_guard/blob/main/docs/protected-by-niubi-guard.zh-CN.md" rel="noopener">
+  此仓库正在由 Niubi Guard 防护。
+</a>
+```
+
+## 官网或文档站片段
+
+```html
+<section aria-label="Repository protection status">
+  <a href="https://github.com/Albert-Weasker/niubi_guard/blob/main/docs/protected-by-niubi-guard.zh-CN.md" rel="noopener">
+    <img
+      src="https://img.shields.io/badge/protected%20by-niubi_guard-00bcd4?style=for-the-badge"
+      alt="Protected by Niubi Guard"
+    />
+  </a>
+  <p>此仓库使用 Niubi Guard 辅助识别垃圾信息、协同滥用和重复攻击模板。</p>
+</section>
+```
+
+## 未来动态徽章
+
+当前推荐使用静态 Shields 徽章。未来可以增加官网动态端点：
+
+```html
+<img
+  src="https://www.niubistar.com/guard/badge.svg?repo=owner/repo"
+  alt="Protected by Niubi Guard"
+/>
+```
+
+如果未来上线动态端点，只有主动接入或可验证已防护的仓库才应返回正向防护状态。
+
+## 移除
+
+如果不再部署 Niubi Guard、不再维护 Guard 策略，或徽章会误导用户理解防护状态，请移除该徽章。


### PR DESCRIPTION
## Summary
- split mixed bilingual docs into README-style locale pairs
- keep English docs in .md files and Chinese docs in .zh-CN.md files
- update Chinese README links to the Chinese docs
- preserve report links, attack corpus, and protected badge protocol content

## Verification
- pnpm check
- checked docs for mixed heading style